### PR TITLE
fix(ai): reject stale AI image writes and project-qualify image storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AI-generated character/world/scene images no longer overwrite the wrong project, and a stale
+  result can no longer be persisted (#704, #708):** `generateCharacterPortraitThunk`,
+  `generateWorldImageThunk`, and `generateSceneImageThunk` now capture the active project's
+  identity before the AI call and reject with a stale-project sentinel *before* the persistent
+  `saveImage`/reducer mutation, closing a race where a project switch mid-generation could apply
+  one project's AI output to another. Image storage keys on both the IndexedDB and desktop
+  filesystem backends are now project-qualified (matching the existing binder-asset convention),
+  with a legacy-key read-through so pre-existing images stay reachable without a forced
+  migration — previously two stored projects sharing an entity id (e.g. one imported from the
+  other's own export) could silently overwrite each other's image. Character Interview streaming
+  now drops chunks once the active project changes mid-stream, and Writer's generation history and
+  Global Copilot's transcript are invalidated on project-generation change so a stale AI result
+  from another project can never be accepted or applied. PR #718.
 - **`extract-zip` eliminated from the dependency graph (Dependabot #86, GHSA-7pqw-9j4j-h8q3 /
   GHSA-jmr9-qjv8-65gv):** the vulnerable package was reachable only via `@lhci/cli`'s hard-pinned
   `lighthouse@12.6.1` → `puppeteer-core` → `@puppeteer/browsers@2.x` chain. A

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7702%2B_%2F_606_files-22C55E" alt="7702+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7720%2B_%2F_606_files-22C55E" alt="7720+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7702+ tests / 606 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7720+ tests / 606 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7702+ tests, 606 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7720+ tests, 606 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7702+ unit tests** across **606 test files** — CI is authoritative for pass/fail
+- **7720+ unit tests** across **606 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -1,11 +1,13 @@
 import type { TypedStartListening } from '@reduxjs/toolkit';
 import { createListenerMiddleware, isRejected } from '@reduxjs/toolkit';
 import { analyticsActions } from '../features/analytics/analyticsSlice';
+import { copilotActions } from '../features/copilot/copilotSlice';
 // QNBS-v3: canonical selector — replaces a local type that misapplied the persisted-state shape to the live store
 import { proForgeActions } from '../features/proForge/proForgeSlice';
 import { selectProjectData } from '../features/project/projectSelectors';
 import type { ProjectData } from '../features/project/projectSlice';
 import { statusActions } from '../features/status/statusSlice';
+import { writerActions } from '../features/writer/writerSlice';
 import { ecoModeService } from '../services/ai/ecoModeService';
 import { extractStoryCodex, saveStoryCodex } from '../services/codexService';
 import { checkStorageHealth } from '../services/dbInitialization';
@@ -881,6 +883,28 @@ export async function initLocalFirstSyncOnStartup(enabled: boolean): Promise<voi
     () => store.getState().featureFlags?.enableLocalFirstSync === true,
   );
 }
+
+// QNBS-v3: Writer's generationHistory is project-unscoped session state -- invalidate it on the shared generation counter so handleAccept() can never insert another project's AI output.
+listenerMiddleware.startListening({
+  predicate: (_action, curr, prev) =>
+    (curr as RootState).project.present.generation !==
+    (prev as RootState).project.present.generation,
+  effect: async (_action, listenerApi) => {
+    listenerApi.dispatch(writerActions.clearHistory());
+    listenerApi.dispatch(writerActions.clearResultStream());
+    listenerApi.dispatch(writerActions.stopLoading());
+  },
+});
+
+// QNBS-v3: Global Copilot's chat transcript is also project-unscoped -- same generation-counter guard so an apply-capable response from project A can't survive into project B.
+listenerMiddleware.startListening({
+  predicate: (_action, curr, prev) =>
+    (curr as RootState).project.present.generation !==
+    (prev as RootState).project.present.generation,
+  effect: async (_action, listenerApi) => {
+    listenerApi.dispatch(copilotActions.clear());
+  },
+});
 
 export const startAppListening = listenerMiddleware.startListening as TypedStartListening<
   RootState,

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useAppDispatch } from '../app/hooks';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { CharacterViewContext, useCharacterViewContext } from '../contexts/CharacterViewContext';
+import { selectProjectData } from '../features/project/projectSelectors';
 import { uploadCharacterImageThunk } from '../features/project/thunks/characterThunks';
 import { useCharacterView } from '../hooks/useCharacterView';
 import { logger } from '../services/logger';
@@ -31,6 +32,7 @@ import { Spinner } from './ui/Spinner';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
+  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
@@ -40,7 +42,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     let isMounted = true;
     const fetchImage = async () => {
       try {
-        const image = await storageService.getImage(id);
+        const image = await storageService.getImage(projectId, id);
         if (isMounted && image) {
           setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
         }
@@ -53,7 +55,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     return () => {
       isMounted = false;
     };
-  }, [id, hasImage]);
+  }, [id, hasImage, projectId]);
   return imageUrl;
 };
 

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useAppDispatch } from '../app/hooks';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { useWorldViewContext, WorldViewContext } from '../contexts/WorldViewContext';
+import { selectProjectData } from '../features/project/projectSelectors';
 import { uploadWorldImageThunk } from '../features/project/thunks/worldThunks';
 import { useWorldView } from '../hooks/useWorldView';
 import { logger } from '../services/logger';
@@ -31,6 +32,7 @@ import { Textarea } from './ui/Textarea';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
+  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
@@ -40,7 +42,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     let isMounted = true;
     const fetchImage = async () => {
       try {
-        const image = await storageService.getImage(id);
+        const image = await storageService.getImage(projectId, id);
         if (isMounted && image) {
           setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
         }
@@ -53,7 +55,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     return () => {
       isMounted = false;
     };
-  }, [id, hasImage]);
+  }, [id, hasImage, projectId]);
   return imageUrl;
 };
 

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -10,6 +10,9 @@ type DeduplicatedThunkAPI = GetThunkAPI<AsyncThunkConfig> & {
   registerDuplicateRequest: (prompt: string, viewType: string) => string;
 };
 
+// QNBS-v3: RTK's RejectWithValue class isn't exported by name; derive its exact instance type structurally from rejectWithValue's own return type so payloadCreator can allow a stale-project reject without importing an internal type.
+type RejectionValue = ReturnType<DeduplicatedThunkAPI['rejectWithValue']>;
+
 const activeControllers = new Map<string, AbortController>();
 
 // Deduplicates AI requests by prompt and view type.
@@ -17,7 +20,10 @@ const activeControllers = new Map<string, AbortController>();
 // pending request for that same key is aborted to prevent spam and race conditions.
 export const createDeduplicatedThunk = <Returned, ThunkArg = void>(
   typePrefix: string,
-  payloadCreator: (arg: ThunkArg, thunkAPI: DeduplicatedThunkAPI) => Promise<Returned>,
+  payloadCreator: (
+    arg: ThunkArg,
+    thunkAPI: DeduplicatedThunkAPI,
+  ) => Promise<Returned | RejectionValue>,
   options?: Parameters<typeof createAsyncThunk<Returned, ThunkArg>>[2],
 ) => {
   return createAsyncThunk<Returned, ThunkArg>(

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -43,3 +43,21 @@ export function captureActiveProjectIdentity(): string | null {
 export function identityUnchanged(captured: string | null, live: string | null): boolean {
   return captured !== null && captured === live;
 }
+
+/** rejectWithValue payload for an AI result discarded because the active project changed while it was in flight. */
+export interface StaleProjectRejection {
+  readonly staleProject: true;
+}
+
+export function staleProjectRejection(): StaleProjectRejection {
+  return { staleProject: true };
+}
+
+// QNBS-v3: distinguishes a deliberate stale-project discard from a genuine provider/network failure so callers can stay silent instead of showing an error toast for a mere project switch.
+export function isStaleProjectRejection(payload: unknown): payload is StaleProjectRejection {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as Record<string, unknown>)['staleProject'] === true
+  );
+}

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -6,6 +6,11 @@ import type { CharacterHeuristicLabels } from '../../../services/ai/heuristicFal
 import { storageService } from '../../../services/storageService';
 import type { Character } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+  staleProjectRejection,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateCharacterProfileThunk = createDeduplicatedThunk(
@@ -71,7 +76,7 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
       style,
       lang,
     }: { characterId: string; description: string; style?: string; lang: string },
-    { getState, signal, registerDuplicateRequest },
+    { getState, signal, registerDuplicateRequest, rejectWithValue },
   ) => {
     const fullDescription = style ? `${description}. Style: ${style}` : description;
     const state = getState() as RootState;
@@ -80,15 +85,22 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
     const { generateImage } = await loadAiProvider();
     const { prompt } = getPrompts('characterPortrait', { description: fullDescription, lang });
     registerDuplicateRequest(prompt, 'characterPortrait');
+    const projectId = state.project.present?.data?.id || 'default';
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const base64 = await generateImage(prompt, aiOptions, signal);
-    await storageService.saveImage(characterId, base64);
+    // QNBS-v3: reject before the persistent write/reducer mutation -- a hook-level check after this thunk resolves would already be too late for saveImage.
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
+      return rejectWithValue(staleProjectRejection());
+    }
+    await storageService.saveImage(projectId, characterId, base64);
     return { characterId };
   },
 );
 
 export const uploadCharacterImageThunk = createAsyncThunk(
   'project/uploadCharacterImage',
-  async ({ characterId, file }: { characterId: string; file: File }) => {
+  async ({ characterId, file }: { characterId: string; file: File }, { getState }) => {
+    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
     return new Promise<{ characterId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -100,7 +112,7 @@ export const uploadCharacterImageThunk = createAsyncThunk(
         }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(characterId, result)
+          .saveImage(projectId, characterId, result)
           .then(() => resolve({ characterId }))
           .catch(reject);
       };

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { RootState } from '../../../app/store';
 import { streamText } from '../../../services/geminiService';
 import type { CharacterArchetype, CharacterInterview, InterviewMessage } from '../../../types';
+import { captureActiveProjectIdentity, identityUnchanged } from '../projectIdentity';
 import { selectAllCharacters } from '../projectSelectors';
 import { projectActions } from '../projectSlice';
 import { buildAiCreativity, buildAiOptions } from './thunkUtils';
@@ -64,6 +65,8 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     const interview = interviews.find((iv) => iv.id === interviewId);
     if (!interview) throw new Error(`Interview ${interviewId} not found`);
 
+    // QNBS-v3: captured before any await -- the streaming callback below re-checks this on every chunk so a project switch/import/reset mid-stream can never mutate the now-active project via these interview/character ids.
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const creativity = buildAiCreativity(state);
     const aiOptions = buildAiOptions(state);
 
@@ -105,6 +108,10 @@ export const streamInterviewResponseThunk = createAsyncThunk(
       creativity,
       (chunk) => {
         accumulated += chunk;
+        // QNBS-v3: a late chunk after the active project changed must never mutate the now-current project via these stale ids -- drop it rather than dispatch.
+        if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
+          return;
+        }
         // QNBS-v3: update the AI message in place via updateCharacterInterview to avoid N dispatches
         dispatch(
           projectActions.updateCharacterInterview({

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -73,10 +73,13 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
     throw new Error('Invalid project file: duplicate character or world entity ID.');
   }
 
+  // QNBS-v3: images are project-qualified in storage now -- resolve the imported project's own id up front so both save loops use the same namespace the returned ProjectData below is assigned.
+  const importedProjectId = projectDataJson.id ?? 'default';
+
   for (const char of characterArray) {
     const newChar = { ...char };
     if (newChar.avatarBase64) {
-      await storageService.saveImage(newChar.id, newChar.avatarBase64);
+      await storageService.saveImage(importedProjectId, newChar.id, newChar.avatarBase64);
       newChar.hasAvatar = true;
       delete newChar.avatarBase64;
     }
@@ -86,7 +89,7 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
   for (const world of worldArray) {
     const newWorld = { ...world };
     if (newWorld.ambianceImageBase64) {
-      await storageService.saveImage(newWorld.id, newWorld.ambianceImageBase64);
+      await storageService.saveImage(importedProjectId, newWorld.id, newWorld.ambianceImageBase64);
       newWorld.hasAmbianceImage = true;
       delete newWorld.ambianceImageBase64;
     }
@@ -101,7 +104,7 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
   const manuscript = projectDataJson.manuscript ?? [];
 
   const result = {
-    id: projectDataJson.id ?? 'default',
+    id: importedProjectId,
     title: projectDataJson.title,
     logline: projectDataJson.logline,
     author: projectDataJson.author,

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -5,6 +5,11 @@ import type { WorldHeuristicLabels } from '../../../services/ai/heuristicFallbac
 import { storageService } from '../../../services/storageService';
 import type { World } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+  staleProjectRejection,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateWorldProfileThunk = createDeduplicatedThunk(
@@ -65,7 +70,7 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
   'project/generateWorldImage',
   async (
     { worldId, description, lang }: { worldId: string; description: string; lang: string },
-    { getState, signal, registerDuplicateRequest },
+    { getState, signal, registerDuplicateRequest, rejectWithValue },
   ) => {
     const state = getState() as RootState;
     const aiOptions = buildAiOptions(state);
@@ -73,15 +78,22 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
     const { generateImage } = await loadAiProvider();
     const { prompt } = getPrompts('worldImage', { description, lang });
     registerDuplicateRequest(prompt, 'worldImage');
+    const projectId = state.project.present?.data?.id || 'default';
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const base64 = await generateImage(prompt, aiOptions, signal);
-    await storageService.saveImage(worldId, base64);
+    // QNBS-v3: reject before the persistent write/reducer mutation -- a hook-level check after this thunk resolves would already be too late for saveImage.
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
+      return rejectWithValue(staleProjectRejection());
+    }
+    await storageService.saveImage(projectId, worldId, base64);
     return { worldId };
   },
 );
 
 export const uploadWorldImageThunk = createAsyncThunk(
   'project/uploadWorldImage',
-  async ({ worldId, file }: { worldId: string; file: File }) => {
+  async ({ worldId, file }: { worldId: string; file: File }, { getState }) => {
+    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
     return new Promise<{ worldId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -93,7 +105,7 @@ export const uploadWorldImageThunk = createAsyncThunk(
         }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(worldId, result)
+          .saveImage(projectId, worldId, result)
           .then(() => resolve({ worldId }))
           .catch(reject);
       };

--- a/features/project/thunks/writingThunks.ts
+++ b/features/project/thunks/writingThunks.ts
@@ -1,6 +1,11 @@
 import type { RootState } from '../../../app/store';
 import { storageService } from '../../../services/storageService';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+  staleProjectRejection,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateLoglineSuggestionsThunk = createDeduplicatedThunk(
@@ -66,7 +71,7 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
       projectTitle: string;
       lang: string;
     },
-    { getState, signal, registerDuplicateRequest },
+    { getState, signal, registerDuplicateRequest, rejectWithValue },
   ) => {
     const state = getState() as RootState;
     const aiOptions = buildAiOptions(state);
@@ -79,9 +84,15 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
       lang: payload.lang,
     });
     registerDuplicateRequest(prompt, 'sceneVisualization');
+    const projectId = state.project.present?.data?.id || 'default';
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const base64 = await generateImage(prompt, aiOptions, signal);
+    // QNBS-v3: reject before the persistent write -- a hook-level check after this thunk resolves would already be too late for saveImage.
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
+      return rejectWithValue(staleProjectRejection());
+    }
     const imageKey = `scene-${payload.sectionId}`;
-    await storageService.saveImage(imageKey, base64);
+    await storageService.saveImage(projectId, imageKey, base64);
     const dataUrl = base64.includes('data:image') ? base64 : `data:image/png;base64,${base64}`;
     return { imageKey, dataUrl };
   },

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -5,8 +5,9 @@ import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
   identityUnchanged,
+  isStaleProjectRejection,
 } from '../features/project/projectIdentity';
-import { selectAllCharacters } from '../features/project/projectSelectors';
+import { selectAllCharacters, selectProjectData } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
@@ -22,6 +23,7 @@ export const useCharacterView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const characters = useAppSelector(selectAllCharacters);
+  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
   const toast = useToast();
 
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
@@ -162,13 +164,14 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+      // Trigger re-render by updating local state, redux state will update via extraReducer
+      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
+    } else if (!isStaleProjectRejection(resultAction.payload)) {
+      // QNBS-v3: a stale-project discard is not a provider failure -- stay silent rather than showing a misleading error for an ordinary project switch.
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
-    } else {
-      // Trigger re-render by updating local state, redux state will update via extraReducer
-      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
     }
     setIsGeneratingPortrait(false);
   }, [dispatch, selectedCharacter, portraitStyle, language, t, toast]);
@@ -184,7 +187,11 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateCharacterPortraitThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectRejection(resultAction.payload)
+    ) {
+      // QNBS-v3: a stale-project discard is not a provider failure -- stay silent rather than showing a misleading error for an ordinary project switch.
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
@@ -205,14 +212,14 @@ export const useCharacterView = () => {
 
   const confirmDelete = useCallback(async () => {
     if (characterToDelete) {
-      await storageService.saveImage(characterToDelete.id, ''); // Empty string to delete
+      await storageService.saveImage(projectId, characterToDelete.id, ''); // Empty string to delete
       dispatch(projectActions.deleteCharacter(characterToDelete.id));
       setCharacterToDelete(null);
       setIsDossierOpen(false);
       setSelectedCharacter(null);
       toast.info(t('characters.deleteLabel', { name: characterToDelete.name }));
     }
-  }, [dispatch, characterToDelete, toast, t]);
+  }, [dispatch, characterToDelete, toast, t, projectId]);
 
   return {
     t,

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useTransientUiStore } from '../app/transientUiStore';
 import { useToast } from '../components/ui/Toast';
+import { isStaleProjectRejection } from '../features/project/projectIdentity';
 import {
   selectAllCharacters,
   selectAllWorlds,
@@ -325,8 +326,11 @@ export const useManuscriptView = ({
       ).unwrap();
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
-    } catch {
-      toast.error(t('error.apiErrorTitle'));
+    } catch (err) {
+      // QNBS-v3: a stale-project discard is not a provider failure -- the active project changed while the request was in flight; stay silent rather than showing a misleading API-error toast.
+      if (!isStaleProjectRejection(err)) {
+        toast.error(t('error.apiErrorTitle'));
+      }
     } finally {
       setIsSceneVisualizing(false);
     }

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -5,8 +5,9 @@ import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
   identityUnchanged,
+  isStaleProjectRejection,
 } from '../features/project/projectIdentity';
-import { selectAllWorlds } from '../features/project/projectSelectors';
+import { selectAllWorlds, selectProjectData } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateWorldImageThunk,
@@ -22,6 +23,7 @@ export const useWorldView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const worlds = useAppSelector(selectAllWorlds);
+  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
   const toast = useToast();
 
   const [selectedWorld, setSelectedWorld] = useState<World | null>(null);
@@ -156,7 +158,8 @@ export const useWorldView = () => {
     );
     if (generateWorldImageThunk.fulfilled.match(resultAction)) {
       setSelectedWorld((w) => (w ? { ...w, hasAmbianceImage: true } : null));
-    } else {
+    } else if (!isStaleProjectRejection(resultAction.payload)) {
+      // QNBS-v3: a stale-project discard is not a provider failure -- stay silent rather than showing a misleading error for an ordinary project switch.
       toast.error(t('worlds.error.imageFailed'));
     }
     setIsGeneratingImage(false);
@@ -169,7 +172,10 @@ export const useWorldView = () => {
     const resultAction = await dispatch(
       generateWorldImageThunk({ worldId: selectedWorld.id, description, lang: language }),
     );
-    if (!generateWorldImageThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateWorldImageThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectRejection(resultAction.payload)
+    ) {
       toast.error(t('worlds.error.imageFailed'));
     }
     setRefinementPrompt('');
@@ -243,14 +249,14 @@ export const useWorldView = () => {
 
   const confirmDelete = useCallback(async () => {
     if (worldToDelete) {
-      await storageService.saveImage(worldToDelete.id, ''); // Empty string to delete
+      await storageService.saveImage(projectId, worldToDelete.id, ''); // Empty string to delete
       dispatch(projectActions.deleteWorld(worldToDelete.id));
       setWorldToDelete(null);
       setIsAtlasOpen(false);
       setSelectedWorld(null);
       toast.info(t('worlds.deleteLabel', { name: worldToDelete.name }));
     }
-  }, [dispatch, worldToDelete, toast, t]);
+  }, [dispatch, worldToDelete, toast, t, projectId]);
 
   return {
     t,

--- a/services/cloudSync/cloudSyncBackend.ts
+++ b/services/cloudSync/cloudSyncBackend.ts
@@ -170,16 +170,16 @@ export class CloudSyncBackend implements StorageBackend {
 
   // --- Not synced to cloud (security / size constraints) ---
 
-  async saveImage(_id: string, _base64Data: string): Promise<void> {
+  async saveImage(_projectId: string, _id: string, _base64Data: string): Promise<void> {
     // QNBS-v3: Images are not synced — large binary blobs belong in local IDB.
     throw new Error('CloudSyncBackend: image storage is local-only');
   }
 
-  async getImage(_id: string): Promise<string | null> {
+  async getImage(_projectId: string, _id: string): Promise<string | null> {
     throw new Error('CloudSyncBackend: image storage is local-only');
   }
 
-  async deleteImage(_id: string): Promise<void> {
+  async deleteImage(_projectId: string, _id: string): Promise<void> {
     throw new Error('CloudSyncBackend: image storage is local-only');
   }
 

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -12,32 +12,43 @@ import { FsSnapshotStore } from './snapshotFsStore';
 export class FsAssetStore extends FsSnapshotStore {
   // --- Image Store Methods ---
 
-  async saveImage(id: string, base64Data: string): Promise<void> {
+  // QNBS-v3: images previously lived in one flat dir keyed only by entity id, colliding across the desktop backend's multiple stored projects -- nest per-project going forward; getImage/deleteImage still fall through to the legacy flat path.
+  private async qualifiedImagePaths(
+    projectId: string,
+    id: string,
+  ): Promise<{ dir: string; file: string }> {
     const apis = await this.getApis();
     const appDataPath = await this.ensureAppDataPath();
-    const imagesPath = await apis.join(appDataPath, 'images');
-
-    if (!(await apis.exists(imagesPath))) {
-      await apis.mkdir(imagesPath, { recursive: true });
-    }
-
-    const imageFile = await apis.join(imagesPath, `${sanitizePathSegment(id, 'image')}.png`);
-    // QNBS-v3: data URLs retain an uploaded image's MIME type; legacy raw payloads remain readable as PNG below.
-    await writeTextFileAtomic(apis, imageFile, base64Data);
+    const dir = await apis.join(appDataPath, 'images', sanitizePathSegment(projectId, 'project'));
+    const file = await apis.join(dir, `${sanitizePathSegment(id, 'image')}.png`);
+    return { dir, file };
   }
 
-  async getImage(id: string): Promise<string | null> {
+  private async legacyImagePath(id: string): Promise<string> {
+    const apis = await this.getApis();
+    const appDataPath = await this.ensureAppDataPath();
+    return apis.join(appDataPath, 'images', `${sanitizePathSegment(id, 'image')}.png`);
+  }
+
+  async saveImage(projectId: string, id: string, base64Data: string): Promise<void> {
+    const apis = await this.getApis();
+    const { dir, file } = await this.qualifiedImagePaths(projectId, id);
+    if (!(await apis.exists(dir))) {
+      await apis.mkdir(dir, { recursive: true });
+    }
+    // QNBS-v3: data URLs retain an uploaded image's MIME type; legacy raw payloads remain readable as PNG below.
+    await writeTextFileAtomic(apis, file, base64Data);
+  }
+
+  async getImage(projectId: string, id: string): Promise<string | null> {
     try {
       const apis = await this.getApis();
-      const appDataPath = await this.ensureAppDataPath();
-      const imageFile = await apis.join(
-        appDataPath,
-        'images',
-        `${sanitizePathSegment(id, 'image')}.png`,
-      );
-
+      let imageFile = (await this.qualifiedImagePaths(projectId, id)).file;
       if (!(await apis.exists(imageFile))) {
-        return null;
+        imageFile = await this.legacyImagePath(id);
+        if (!(await apis.exists(imageFile))) {
+          return null;
+        }
       }
 
       const imageData = await retryFs(() => apis.readTextFile(imageFile));
@@ -48,17 +59,17 @@ export class FsAssetStore extends FsSnapshotStore {
     }
   }
 
-  async deleteImage(id: string): Promise<void> {
+  async deleteImage(projectId: string, id: string): Promise<void> {
     try {
       const apis = await this.getApis();
-      const appDataPath = await this.ensureAppDataPath();
-      const imageFile = await apis.join(
-        appDataPath,
-        'images',
-        `${sanitizePathSegment(id, 'image')}.png`,
-      );
-      if (await apis.exists(imageFile)) {
-        await retryFs(() => apis.remove(imageFile));
+      // QNBS-v3: clear both the qualified and legacy path so a stale legacy file can never resurface via getImage's fallback after an explicit delete.
+      for (const imageFile of [
+        (await this.qualifiedImagePaths(projectId, id)).file,
+        await this.legacyImagePath(id),
+      ]) {
+        if (await apis.exists(imageFile)) {
+          await retryFs(() => apis.remove(imageFile));
+        }
       }
     } catch (error) {
       logger.error('Failed to delete image:', error);

--- a/services/fs/projectFsStore.ts
+++ b/services/fs/projectFsStore.ts
@@ -1235,6 +1235,8 @@ export class FsProjectStore extends FsAssetStore {
 
     if (filePath.endsWith('.json')) {
       const parsed = parseImportedProjectJson(content);
+      // QNBS-v3: images are now project-qualified in storage; use the imported project's own id (matching importProjectThunk's web-path convention) so entity images land under the correct namespace.
+      const importedProjectId = parsed.id ?? 'default';
       type CharRow = Character & { avatarBase64?: string };
       type WorldRow = World & { ambianceImageBase64?: string };
       let characterArray: CharRow[] = [];
@@ -1250,7 +1252,7 @@ export class FsProjectStore extends FsAssetStore {
       for (const char of characterArray) {
         const row = { ...char };
         if (row.avatarBase64) {
-          await this.saveImage(row.id, row.avatarBase64);
+          await this.saveImage(importedProjectId, row.id, row.avatarBase64);
           row.hasAvatar = true;
           delete row.avatarBase64;
         }
@@ -1270,7 +1272,7 @@ export class FsProjectStore extends FsAssetStore {
       for (const world of worldArray) {
         const row = { ...world };
         if (row.ambianceImageBase64) {
-          await this.saveImage(row.id, row.ambianceImageBase64);
+          await this.saveImage(importedProjectId, row.id, row.ambianceImageBase64);
           row.hasAmbianceImage = true;
           delete row.ambianceImageBase64;
         }

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -6,7 +6,11 @@
 
 import { BINDER_ASSETS_STORE, IMAGES_STORE } from '../dbConstants';
 import type { BinderAssetMeta, BinderAssetPayload } from '../storageBackend';
-import { makeBinderAssetIdsPrefix, makeBinderAssetStorageKey } from '../storageBackend';
+import {
+  makeBinderAssetIdsPrefix,
+  makeBinderAssetStorageKey,
+  makeImageStorageKey,
+} from '../storageBackend';
 import { getUserFriendlyDbError, retryDb } from './idbCore';
 import { IdbSnapshotStore } from './idbSnapshotStore';
 import { withProtectedWriteAdmission } from './protectedWriteAdmission';
@@ -23,7 +27,7 @@ import {
 export class IdbAssetStore extends IdbSnapshotStore {
   // --- Image Store Methods ---
 
-  async saveImage(id: string, base64: string): Promise<void> {
+  async saveImage(projectId: string, id: string, base64: string): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: Resolve the write key BEFORE opening the transaction — `await idbEncryptWithKey`
       //          yields the event loop, which auto-commits an already-open IDB transaction
@@ -35,49 +39,59 @@ export class IdbAssetStore extends IdbSnapshotStore {
       await assertNoActiveEncryptionMigration();
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       return new Promise<void>((resolve, reject) => {
-        const request = store.put(payload, id);
+        const request = store.put(payload, makeImageStorageKey(projectId, id));
         request.onsuccess = () => resolve();
         request.onerror = () => reject(request.error);
       });
     });
   }
 
-  async getImage(id: string): Promise<string | null> {
-    // QNBS-v3: assertSecureStorageReadable also blocks reads during an active journal migration, not just a plain lock — the superset check needed while a journal owns lifecycle state.
-    await assertSecureStorageReadable();
-    const store = await this.getObjectStore(IMAGES_STORE, 'readonly');
-    return new Promise((resolve, reject) => {
-      const request = store.get(id);
-      // QNBS-v3: IDBRequest.onsuccess is not awaited by the browser — an async handler whose
-      //          promise rejects becomes an unhandled rejection instead of reaching this
-      //          Promise's reject, leaving the caller pending instead of surfacing the error.
-      request.onsuccess = () => {
-        const raw = request.result;
-        if (raw == null) {
-          resolve(null);
-          return;
-        }
-        // QNBS-v3: Decrypt encrypted image payload; legacy plaintext falls through.
-        if (raw instanceof Uint8Array && isEncryptedBlob(raw)) {
-          idbReadSecure<string>(raw).then(resolve).catch(reject);
-          return;
-        }
-        resolve(raw as string);
-      };
-      request.onerror = () => reject(request.error);
-    });
+  // QNBS-v3: decodes one raw IMAGES_STORE record (legacy plaintext or encrypted) into its base64 string.
+  private decodeImageRecord(raw: unknown): Promise<string | null> | string | null {
+    if (raw == null) return null;
+    if (raw instanceof Uint8Array && isEncryptedBlob(raw)) {
+      return idbReadSecure<string>(raw);
+    }
+    return raw as string;
   }
 
-  async deleteImage(id: string): Promise<void> {
+  private getRawImage(key: string): Promise<unknown> {
+    return this.getObjectStore(IMAGES_STORE, 'readonly').then(
+      (store) =>
+        new Promise<unknown>((resolve, reject) => {
+          const request = store.get(key);
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        }),
+    );
+  }
+
+  async getImage(projectId: string, id: string): Promise<string | null> {
+    // QNBS-v3: assertSecureStorageReadable also blocks reads during an active journal migration, not just a plain lock — the superset check needed while a journal owns lifecycle state.
+    await assertSecureStorageReadable();
+    const qualified = await this.getRawImage(makeImageStorageKey(projectId, id));
+    if (qualified != null) return this.decodeImageRecord(qualified);
+    // QNBS-v3: fall back to the pre-project-qualification key so pre-existing images stay reachable without a forced rewrite/migration.
+    const legacy = await this.getRawImage(id);
+    return this.decodeImageRecord(legacy);
+  }
+
+  async deleteImage(projectId: string, id: string): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: A locked session must not be able to destroy protected images it cannot read.
       await assertIdbProtectedWriteAllowed();
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
-      return new Promise<void>((resolve, reject) => {
-        const request = store.delete(id);
-        request.onsuccess = () => resolve();
-        request.onerror = () => reject(request.error);
-      });
+      // QNBS-v3: clear both the qualified and legacy key so a stale legacy record can never resurface via getImage's fallback after an explicit delete.
+      await Promise.all(
+        [makeImageStorageKey(projectId, id), id].map(
+          (key) =>
+            new Promise<void>((resolve, reject) => {
+              const request = store.delete(key);
+              request.onsuccess = () => resolve();
+              request.onerror = () => reject(request.error);
+            }),
+        ),
+      );
     });
   }
 

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -32,6 +32,13 @@ export function makeBinderAssetIdsPrefix(projectId: string): string {
   return `${safeProject}::`;
 }
 
+// QNBS-v3: images were previously keyed only by entity id, so two stored projects sharing an id (e.g. import preserves ids verbatim) could overwrite each other's image -- project-qualify going forward, with a legacy-key read-through.
+/** IndexedDB / filesystem key for a project-scoped image — same delimiter convention as binder assets. */
+export function makeImageStorageKey(projectId: string, entityId: string): string {
+  const safeProject = projectId.replace(/[\s:]/g, '_').slice(0, 200);
+  return `${safeProject}::${entityId}`;
+}
+
 /**
  * Redux-undo / auto-save shape (not a flat `StoryProject` export).
  * Kept separate from `StoryProject` so call-sites can type auto-save without casts.
@@ -84,8 +91,8 @@ export interface StorageBackend {
   // QNBS-v3: optional recovery keeps the filesystem-only quarantine contract out of IndexedDB.
   quarantineProject?(projectId: string): Promise<ProjectQuarantineResult>;
 
-  saveImage(id: string, base64Data: string): Promise<void>;
-  getImage(id: string): Promise<string | null>;
+  saveImage(projectId: string, id: string, base64Data: string): Promise<void>;
+  getImage(projectId: string, id: string): Promise<string | null>;
 
   saveSettings(settings: Settings): Promise<void>;
   loadSettings(): Promise<Settings | null>;
@@ -106,7 +113,7 @@ export interface StorageBackend {
   listSnapshots(): Promise<ProjectSnapshot[]>;
   deleteSnapshot(snapshotId: number): Promise<void>;
 
-  deleteImage(id: string): Promise<void>;
+  deleteImage(projectId: string, id: string): Promise<void>;
 
   hasSavedData(): Promise<boolean>;
 

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -113,14 +113,14 @@ class StorageManager {
     return backend.deleteProject(projectId);
   }
 
-  async saveImage(id: string, base64Data: string): Promise<void> {
+  async saveImage(projectId: string, id: string, base64Data: string): Promise<void> {
     const backend = await this.getBackend();
-    return backend.saveImage(id, base64Data);
+    return backend.saveImage(projectId, id, base64Data);
   }
 
-  async getImage(id: string): Promise<string | null> {
+  async getImage(projectId: string, id: string): Promise<string | null> {
     const backend = await this.getBackend();
-    return backend.getImage(id);
+    return backend.getImage(projectId, id);
   }
 
   async saveSettings(settings: Settings): Promise<void> {
@@ -187,9 +187,9 @@ class StorageManager {
     return backend.deleteSnapshot(id);
   }
 
-  async deleteImage(id: string): Promise<void> {
+  async deleteImage(projectId: string, id: string): Promise<void> {
     const backend = await this.getBackend();
-    return backend.deleteImage(id);
+    return backend.deleteImage(projectId, id);
   }
 
   async hasSavedData(): Promise<boolean> {

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -193,7 +193,9 @@ describe('CharacterView', () => {
       ],
     } as never);
     render(<CharacterView />);
-    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-broken'));
+    await waitFor(() =>
+      expect(storageService.getImage).toHaveBeenCalledWith('default', 'c-broken'),
+    );
     expect(screen.queryByAltText('Robin')).toBeNull();
   });
 });

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -192,7 +192,9 @@ describe('WorldView', () => {
       ],
     } as never);
     render(<WorldView />);
-    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-broken'));
+    await waitFor(() =>
+      expect(storageService.getImage).toHaveBeenCalledWith('default', 'w-broken'),
+    );
     expect(screen.queryByAltText('Cindralis')).toBeNull();
   });
 });

--- a/tests/unit/cloudSyncBackend.test.ts
+++ b/tests/unit/cloudSyncBackend.test.ts
@@ -171,12 +171,12 @@ describe('CloudSyncBackend', () => {
 
   it('saveImage throws (images are local-only)', async () => {
     const backend = makeBackend();
-    await expect(backend.saveImage('img-1', 'base64data')).rejects.toThrow('local-only');
+    await expect(backend.saveImage('proj-1', 'img-1', 'base64data')).rejects.toThrow('local-only');
   });
 
   it('getImage throws (images are local-only)', async () => {
     const backend = makeBackend();
-    await expect(backend.getImage('img-1')).rejects.toThrow('local-only');
+    await expect(backend.getImage('proj-1', 'img-1')).rejects.toThrow('local-only');
   });
 
   it('saveGeminiApiKey throws (API keys are local-only)', async () => {

--- a/tests/unit/fileSystemService.test.ts
+++ b/tests/unit/fileSystemService.test.ts
@@ -96,7 +96,7 @@ describe('fileSystemService', () => {
 
   it('getImage() returns null when Tauri unavailable', async () => {
     const { fileSystemService } = await import('../../services/fileSystemService');
-    const result = await fileSystemService.getImage('img-1').catch(() => null);
+    const result = await fileSystemService.getImage('proj-1', 'img-1').catch(() => null);
     expect(result).toBeNull();
   });
 

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -47,12 +47,18 @@ vi.mock('../../../components/ui/Toast', () => ({
 
 vi.mock('../../../features/project/projectSelectors', () => ({
   selectAllCharacters: (state: { characters: Character[] }) => state.characters,
+  // QNBS-v3: not exercised by this file's fake state -- confirmDelete's projectId falls back to 'default'.
+  selectProjectData: () => undefined,
 }));
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  isStaleProjectRejection: (payload: unknown) =>
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as Record<string, unknown>)['staleProject'] === true,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {
@@ -79,7 +85,10 @@ vi.mock('../../../features/project/thunks/characterThunks', () => {
 });
 
 vi.mock('../../../services/storageService', () => ({
-  storageService: { saveImage: (data: unknown, name: unknown) => mockSaveImage(data, name) },
+  storageService: {
+    saveImage: (projectId: unknown, id: unknown, data: unknown) =>
+      mockSaveImage(projectId, id, data),
+  },
 }));
 
 // uuid always returns the same id so assertions are deterministic
@@ -393,6 +402,26 @@ describe('handleGeneratePortrait', () => {
     expect(mockToast.error).toHaveBeenCalled();
     expect(result.current.errorMessage).not.toBeNull();
   });
+
+  // QNBS-v3: Wave 0B.1 -- a stale-project discard is not a provider failure; stay silent.
+  it('does not call toast.error when rejected with a stale-project payload', async () => {
+    const rejectedAction = {
+      type: 'project/generateCharacterPortrait/rejected',
+      payload: { staleProject: true },
+    };
+    mockDispatch.mockResolvedValue(rejectedAction);
+    mockPortraitMatch.mockReturnValue(false);
+
+    const char = makeCharacter('c1');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.handleSelect(char));
+    await act(async () => {
+      await result.current.handleGeneratePortrait();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(result.current.errorMessage).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -425,7 +454,7 @@ describe('confirmDelete', () => {
       await result.current.confirmDelete();
     });
 
-    expect(mockSaveImage).toHaveBeenCalledWith('c1', '');
+    expect(mockSaveImage).toHaveBeenCalledWith('default', 'c1', '');
     expect(mockDispatch).toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 

--- a/tests/unit/hooks/useManuscriptView.test.ts
+++ b/tests/unit/hooks/useManuscriptView.test.ts
@@ -414,6 +414,17 @@ describe('handleVisualizeScene', () => {
     expect(mockToast.error).toHaveBeenCalled();
   });
 
+  // QNBS-v3: Wave 0B.1 -- a stale-project discard is not a provider failure; the project merely changed.
+  it('does not call toast.error when the rejection is a stale-project discard', async () => {
+    mockUnwrap.mockRejectedValue({ staleProject: true });
+    setManuscript([makeSection('s1', 'Ch1', 'Scene content')]);
+    const { result } = renderHook(() => useManuscriptView({ onNavigate }));
+    await act(async () => {
+      await result.current.handleVisualizeScene();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it('does nothing when active section has no content', async () => {
     setManuscript([makeSection('s1', 'Ch1', '')]);
     const { result } = renderHook(() => useManuscriptView({ onNavigate }));

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -45,12 +45,18 @@ vi.mock('../../../components/ui/Toast', () => ({
 
 vi.mock('../../../features/project/projectSelectors', () => ({
   selectAllWorlds: () => mockWorlds,
+  selectProjectData: (state: { project: { present: { data: unknown } } }) =>
+    state.project.present.data,
 }));
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  isStaleProjectRejection: (payload: unknown) =>
+    typeof payload === 'object' &&
+    payload !== null &&
+    (payload as Record<string, unknown>)['staleProject'] === true,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {
@@ -78,7 +84,10 @@ vi.mock('../../../features/project/thunks/worldThunks', () => {
 });
 
 vi.mock('../../../services/storageService', () => ({
-  storageService: { saveImage: (id: unknown, data: unknown) => mockSaveImage(id, data) },
+  storageService: {
+    saveImage: (projectId: unknown, id: unknown, data: unknown) =>
+      mockSaveImage(projectId, id, data),
+  },
 }));
 
 vi.mock('uuid', () => ({ v4: () => 'test-uuid-world' }));
@@ -364,6 +373,22 @@ describe('handleGenerateImage', () => {
     expect(mockToast.error).toHaveBeenCalled();
   });
 
+  // QNBS-v3: Wave 0B.1 -- a stale-project discard is not a provider failure; stay silent.
+  it('does not call toast.error when rejected with a stale-project payload', async () => {
+    const world = makeWorld('w1');
+    mockDispatch.mockResolvedValue({ type: 'rejected', payload: { staleProject: true } });
+    mockImageMatch.mockReturnValue(false);
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => {
+      result.current.handleSelect(world);
+    });
+    await act(async () => {
+      await result.current.handleGenerateImage();
+    });
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it('sets hasAmbianceImage on success', async () => {
     const world = makeWorld('w1');
     mockDispatch.mockResolvedValue({ type: 'fulfilled' });
@@ -415,7 +440,7 @@ describe('confirmDelete', () => {
     await act(async () => {
       await result.current.confirmDelete();
     });
-    expect(mockSaveImage).toHaveBeenCalledWith('w1', '');
+    expect(mockSaveImage).toHaveBeenCalledWith('default', 'w1', '');
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
     );

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -5,6 +5,7 @@ import { listenerMiddleware } from '../../app/listenerMiddleware';
 import type { RootState } from '../../app/store';
 import { useTransientUiStore } from '../../app/transientUiStore';
 import analyticsReducer, { analyticsActions } from '../../features/analytics/analyticsSlice';
+import copilotReducer, { copilotActions } from '../../features/copilot/copilotSlice';
 // QNBS-v3: featureFlagsActions dispatches setEnableLocalFirstSync to exercise the local-first listener below
 import featureFlagsReducer, {
   featureFlagsActions,
@@ -16,6 +17,7 @@ import projectReducer, { projectActions } from '../../features/project/projectSl
 import settingsReducer, { settingsActions } from '../../features/settings/settingsSlice';
 import statusReducer, { statusActions } from '../../features/status/statusSlice';
 import versionControlReducer from '../../features/versionControl/versionControlSlice';
+import writerReducer, { writerActions } from '../../features/writer/writerSlice';
 import { isIdbEncryptionReady } from '../../services/storage/storageEncryptionService';
 
 // ---------------------------------------------------------------------------
@@ -198,6 +200,8 @@ function makeFullStore() {
       featureFlags: featureFlagsReducer,
       analytics: analyticsReducer,
       proForge: proForgeReducer,
+      writer: writerReducer,
+      copilot: copilotReducer,
     },
     middleware: (getDefault) => getDefault().prepend(listenerMiddleware.middleware),
   });
@@ -799,5 +803,61 @@ describe('desktop notification listener (ProForge stageCompleted)', () => {
     await vi.runAllTimersAsync();
 
     expect(mockSendDesktopNotification).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 0B.1: Writer/Copilot ephemeral state invalidation on project-incarnation change
+// ---------------------------------------------------------------------------
+describe('project-generation-change invalidation (Writer + Copilot)', () => {
+  it('clears Writer generationHistory/resultStream/isLoading when the project generation changes', async () => {
+    const store = makeFullStore();
+    store.dispatch(writerActions.addHistory('A-originating generated text'));
+    store.dispatch(writerActions.appendResultStream('streamed chunk'));
+    store.dispatch(writerActions.startLoading());
+    expect(store.getState().writer.generationHistory).toEqual(['A-originating generated text']);
+
+    // QNBS-v3: resetProject bumps state.project.present.generation -- the exact signal the listener watches.
+    store.dispatch(
+      projectActions.resetProject({ title: 'New', logline: '', chapter1Title: 'Ch1' }),
+    );
+    await vi.runAllTimersAsync();
+
+    expect(store.getState().writer.generationHistory).toEqual([]);
+    expect(store.getState().writer.activeHistoryIndex).toBe(-1);
+    expect(store.getState().writer.resultStream).toBe('');
+    expect(store.getState().writer.isLoading).toBe(false);
+  });
+
+  it('does not clear Writer state for unrelated project edits that do not bump generation', async () => {
+    const store = makeFullStore();
+    store.dispatch(writerActions.addHistory('kept text'));
+    store.dispatch(projectActions.updateTitle('Renamed'));
+    await vi.runAllTimersAsync();
+
+    expect(store.getState().writer.generationHistory).toEqual(['kept text']);
+  });
+
+  it('clears the Copilot transcript when the project generation changes', async () => {
+    const store = makeFullStore();
+    store.dispatch(copilotActions.addMessage('user', 'Rewrite this scene for project A'));
+    expect(store.getState().copilot.messages).toHaveLength(1);
+
+    store.dispatch(
+      projectActions.resetProject({ title: 'New', logline: '', chapter1Title: 'Ch1' }),
+    );
+    await vi.runAllTimersAsync();
+
+    expect(store.getState().copilot.messages).toEqual([]);
+    expect(store.getState().copilot.status).toBe('idle');
+  });
+
+  it('does not clear the Copilot transcript for unrelated project edits that do not bump generation', async () => {
+    const store = makeFullStore();
+    store.dispatch(copilotActions.addMessage('user', 'kept message'));
+    store.dispatch(projectActions.updateTitle('Renamed'));
+    await vi.runAllTimersAsync();
+
+    expect(store.getState().copilot.messages).toHaveLength(1);
   });
 });

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1916,15 +1916,35 @@ describe('FsCodexStore — codex + RAG vectors', () => {
 
 describe('FsAssetStore — images + binder assets', () => {
   it('round-trips an image while preserving its data-url MIME type', async () => {
-    await store.saveImage('char-1', 'data:image/webp;base64,QUJD');
-    expect(await store.getImage('char-1')).toBe('data:image/webp;base64,QUJD');
-    await store.deleteImage('char-1');
-    expect(await store.getImage('char-1')).toBeNull();
+    await store.saveImage('proj-1', 'char-1', 'data:image/webp;base64,QUJD');
+    expect(await store.getImage('proj-1', 'char-1')).toBe('data:image/webp;base64,QUJD');
+    await store.deleteImage('proj-1', 'char-1');
+    expect(await store.getImage('proj-1', 'char-1')).toBeNull();
   });
 
   it('treats legacy raw image payloads as PNG', async () => {
-    await store.saveImage('legacy-char', 'QUJD');
-    expect(await store.getImage('legacy-char')).toBe('data:image/png;base64,QUJD');
+    await store.saveImage('proj-1', 'legacy-char', 'QUJD');
+    expect(await store.getImage('proj-1', 'legacy-char')).toBe('data:image/png;base64,QUJD');
+  });
+
+  it('writes new images under a per-project subdirectory, not the flat legacy path', async () => {
+    await store.saveImage('proj-1', 'char-1', 'data:image/webp;base64,QUJD');
+    expect(fake.text.has('/app/images/proj-1/char-1.png')).toBe(true);
+    expect(fake.text.has('/app/images/char-1.png')).toBe(false);
+  });
+
+  // QNBS-v3: a pre-migration flat-path image (written before project-qualified keys existed) must stay reachable without a forced migration.
+  it('falls back to the legacy flat image path when the project-qualified file is absent', async () => {
+    fake.text.set('/app/images/legacy-only.png', 'data:image/png;base64,OLD');
+    expect(await store.getImage('proj-1', 'legacy-only')).toBe('data:image/png;base64,OLD');
+  });
+
+  it('deletes both the project-qualified and legacy flat image files', async () => {
+    fake.text.set('/app/images/dual.png', 'data:image/png;base64,LEGACYCOPY');
+    await store.saveImage('proj-1', 'dual', 'data:image/png;base64,NEWCOPY');
+    await store.deleteImage('proj-1', 'dual');
+    expect(await store.getImage('proj-1', 'dual')).toBeNull();
+    expect(fake.text.has('/app/images/dual.png')).toBe(false);
   });
 
   it('round-trips a binder binary asset with metadata', async () => {

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -50,6 +50,8 @@ vi.mock('../../../../services/storageBackend', () => ({
     `${projectId.replace(/[\s:]/g, '_').slice(0, 200)}::`,
   makeBinderAssetStorageKey: (projectId: string, assetId: string) =>
     `${projectId.replace(/[\s:]/g, '_').slice(0, 200)}::${assetId}`,
+  makeImageStorageKey: (projectId: string, entityId: string) =>
+    `${projectId.replace(/[\s:]/g, '_').slice(0, 200)}::${entityId}`,
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -84,47 +86,63 @@ describe('IdbAssetStore', () => {
   });
 
   describe('saveImage', () => {
-    it('calls put with base64 payload and key', async () => {
+    it('calls put with base64 payload and the project-qualified key', async () => {
       mockIdbStore.put.mockImplementation(() => makeSuccessReq(undefined));
-      await store.saveImage('img-1', 'data:image/png;base64,abc');
-      expect(mockIdbStore.put).toHaveBeenCalledWith('data:image/png;base64,abc', 'img-1');
+      await store.saveImage('proj-1', 'img-1', 'data:image/png;base64,abc');
+      expect(mockIdbStore.put).toHaveBeenCalledWith('data:image/png;base64,abc', 'proj-1::img-1');
     });
 
     it('rejects when IDB put errors', async () => {
       mockIdbStore.put.mockImplementation(() => makeErrorReq(new DOMException('put failed')));
-      await expect(store.saveImage('img-1', 'abc')).rejects.toBeDefined();
+      await expect(store.saveImage('proj-1', 'img-1', 'abc')).rejects.toBeDefined();
     });
   });
 
   describe('getImage', () => {
-    it('returns null when key is absent', async () => {
+    it('returns null when neither the qualified nor legacy key exists', async () => {
       mockIdbStore.get.mockImplementation(() => makeSuccessReq(null));
-      const result = await store.getImage('missing-id');
+      const result = await store.getImage('proj-1', 'missing-id');
       expect(result).toBeNull();
     });
 
-    it('returns the stored base64 string', async () => {
-      mockIdbStore.get.mockImplementation(() => makeSuccessReq('data:image/png;base64,XYZ'));
-      const result = await store.getImage('img-1');
+    it('returns the stored base64 string from the project-qualified key', async () => {
+      mockIdbStore.get.mockImplementation((key: string) =>
+        makeSuccessReq(key === 'proj-1::img-1' ? 'data:image/png;base64,XYZ' : null),
+      );
+      const result = await store.getImage('proj-1', 'img-1');
       expect(result).toBe('data:image/png;base64,XYZ');
+      expect(mockIdbStore.get).toHaveBeenCalledWith('proj-1::img-1');
+    });
+
+    // QNBS-v3: pre-project-qualification images must stay reachable without a forced migration.
+    it('falls back to the legacy unqualified key when the qualified key is absent', async () => {
+      mockIdbStore.get.mockImplementation((key: string) =>
+        makeSuccessReq(key === 'img-1' ? 'data:image/png;base64,LEGACY' : null),
+      );
+      const result = await store.getImage('proj-1', 'img-1');
+      expect(result).toBe('data:image/png;base64,LEGACY');
+      expect(mockIdbStore.get).toHaveBeenCalledWith('proj-1::img-1');
+      expect(mockIdbStore.get).toHaveBeenCalledWith('img-1');
     });
 
     it('rejects when IDB get errors', async () => {
       mockIdbStore.get.mockImplementation(() => makeErrorReq(new DOMException('get failed')));
-      await expect(store.getImage('img-1')).rejects.toBeDefined();
+      await expect(store.getImage('proj-1', 'img-1')).rejects.toBeDefined();
     });
   });
 
   describe('deleteImage', () => {
-    it('calls delete with the given id', async () => {
+    // QNBS-v3: both keys must be cleared so a stale legacy record can never resurface via getImage's fallback.
+    it('deletes both the qualified and legacy key', async () => {
       mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
-      await store.deleteImage('img-1');
+      await store.deleteImage('proj-1', 'img-1');
+      expect(mockIdbStore.delete).toHaveBeenCalledWith('proj-1::img-1');
       expect(mockIdbStore.delete).toHaveBeenCalledWith('img-1');
     });
 
     it('rejects when IDB delete errors', async () => {
       mockIdbStore.delete.mockImplementation(() => makeErrorReq(new DOMException('del failed')));
-      await expect(store.deleteImage('img-1')).rejects.toBeDefined();
+      await expect(store.deleteImage('proj-1', 'img-1')).rejects.toBeDefined();
     });
   });
 

--- a/tests/unit/storage/idbStoreEncryption.test.ts
+++ b/tests/unit/storage/idbStoreEncryption.test.ts
@@ -115,16 +115,16 @@ describe('IdbAssetStore encryption round-trip', () => {
     await initIdbEncryption('test-pass');
     const store = new IdbAssetStore();
     const base64 = 'data:image/png;base64,iVBORw0KGgo=';
-    await store.saveImage('img-1', base64);
-    const result = await store.getImage('img-1');
+    await store.saveImage('proj-1', 'img-1', base64);
+    const result = await store.getImage('proj-1', 'img-1');
     expect(result).toBe(base64);
   });
 
   it('round-trips image when encryption is inactive', async () => {
     const store = new IdbAssetStore();
     const base64 = 'data:image/png;base64,plain=';
-    await store.saveImage('img-2', base64);
-    const result = await store.getImage('img-2');
+    await store.saveImage('proj-2', 'img-2', base64);
+    const result = await store.getImage('proj-2', 'img-2');
     expect(result).toBe(base64);
   });
 
@@ -178,7 +178,7 @@ describe('configured but locked storage', () => {
       IdbStorageLockedError,
     );
     await expect(
-      assetStore.saveImage('locked', 'data:image/png;base64,blocked'),
+      assetStore.saveImage('locked', 'locked', 'data:image/png;base64,blocked'),
     ).rejects.toBeInstanceOf(IdbStorageLockedError);
     await expect(
       assetStore.saveBinderAsset('locked', 'asset', new ArrayBuffer(0), {
@@ -192,7 +192,7 @@ describe('configured but locked storage', () => {
   it('does not expose legacy protected content while the configured library is locked', async () => {
     const assetStore = new IdbAssetStore();
     const codexStore = new IdbCodexStore();
-    await assetStore.saveImage('legacy-image', 'data:image/png;base64,legacy');
+    await assetStore.saveImage('legacy', 'legacy-image', 'data:image/png;base64,legacy');
     await assetStore.saveBinderAsset('legacy', 'legacy-asset', new ArrayBuffer(1), {
       byteSize: 1,
       mimeType: 'application/pdf',
@@ -207,7 +207,9 @@ describe('configured but locked storage', () => {
     await setupIdbEncryption('test-pass');
     clearIdbEncryptionKey();
 
-    await expect(assetStore.getImage('legacy-image')).rejects.toBeInstanceOf(IdbStorageLockedError);
+    await expect(assetStore.getImage('legacy', 'legacy-image')).rejects.toBeInstanceOf(
+      IdbStorageLockedError,
+    );
     await expect(assetStore.getBinderAsset('legacy', 'legacy-asset')).rejects.toBeInstanceOf(
       IdbStorageLockedError,
     );
@@ -219,7 +221,7 @@ describe('configured but locked storage', () => {
 describe('locked-state guards on destructive and listing operations', () => {
   it('rejects deleteImage, deleteBinderAsset, and listBinderAssetIds while locked', async () => {
     const store = new IdbAssetStore();
-    await store.saveImage('img-1', 'data:image/png;base64,x');
+    await store.saveImage('proj-1', 'img-1', 'data:image/png;base64,x');
     await store.saveBinderAsset('proj-1', 'asset-1', new ArrayBuffer(1), {
       byteSize: 1,
       mimeType: 'application/pdf',
@@ -228,7 +230,9 @@ describe('locked-state guards on destructive and listing operations', () => {
     await setupIdbEncryption('test-pass');
     clearIdbEncryptionKey();
 
-    await expect(store.deleteImage('img-1')).rejects.toBeInstanceOf(IdbStorageLockedError);
+    await expect(store.deleteImage('proj-1', 'img-1')).rejects.toBeInstanceOf(
+      IdbStorageLockedError,
+    );
     await expect(store.deleteBinderAsset('proj-1', 'asset-1')).rejects.toBeInstanceOf(
       IdbStorageLockedError,
     );

--- a/tests/unit/storage/storageEncryptionService.test.ts
+++ b/tests/unit/storage/storageEncryptionService.test.ts
@@ -668,15 +668,15 @@ describe('disable/rotate blocked by a stuck recovery-required journal', () => {
 describe('production migration round-trip with real data', () => {
   it('preserves an image through rekey then disable', async () => {
     await setupIdbEncryption('test-fixture-original-passphrase');
-    await dbService.saveImage('recovery-img', 'recovery-content');
-    expect(await dbService.getImage('recovery-img')).toBe('recovery-content');
+    await dbService.saveImage('recovery-project', 'recovery-img', 'recovery-content');
+    expect(await dbService.getImage('recovery-project', 'recovery-img')).toBe('recovery-content');
 
     await rotateIdbPassphrase('test-fixture-original-passphrase', 'test-fixture-new-passphrase');
-    expect(await dbService.getImage('recovery-img')).toBe('recovery-content');
+    expect(await dbService.getImage('recovery-project', 'recovery-img')).toBe('recovery-content');
 
     await clearIdbPassphrase();
     expect(isIdbEncryptionReady()).toBe(false);
-    expect(await dbService.getImage('recovery-img')).toBe('recovery-content');
+    expect(await dbService.getImage('recovery-project', 'recovery-img')).toBe('recovery-content');
   });
 
   it('preserves a story codex (3-shape dispatch) through rekey then disable', async () => {
@@ -807,7 +807,7 @@ describe('resumeEncryptionMigration (recovery UX)', () => {
 
   it('re-derives keys from passphrases and completes a pending rekey journal', async () => {
     await setupIdbEncryption('test-fixture-original-passphrase');
-    await dbService.saveImage('recovery-img-2', 'recovery-content-2');
+    await dbService.saveImage('recovery-project-2', 'recovery-img-2', 'recovery-content-2');
     const journal = await buildPendingRekeyJournal('test-fixture-new-passphrase');
     clearIdbEncryptionKey();
 
@@ -820,7 +820,9 @@ describe('resumeEncryptionMigration (recovery UX)', () => {
       ).resolves.toBeUndefined();
 
       expect(isIdbEncryptionReady()).toBe(true);
-      expect(await dbService.getImage('recovery-img-2')).toBe('recovery-content-2');
+      expect(await dbService.getImage('recovery-project-2', 'recovery-img-2')).toBe(
+        'recovery-content-2',
+      );
 
       clearIdbEncryptionKey();
       await expect(

--- a/tests/unit/storageService.test.ts
+++ b/tests/unit/storageService.test.ts
@@ -189,8 +189,8 @@ describe('storageService (IndexedDB backend in browser)', () => {
     const result = await storageService.hasSavedData();
     expect(result).toBe(true);
 
-    await storageService.deleteImage('img-1');
-    expect(mockDb.deleteImage).toHaveBeenCalledWith('img-1');
+    await storageService.deleteImage('proj-1', 'img-1');
+    expect(mockDb.deleteImage).toHaveBeenCalledWith('proj-1', 'img-1');
   });
 
   it('reports indexeddb storage backend in web context', async () => {

--- a/tests/unit/thunks/binderAndManagementThunks.test.ts
+++ b/tests/unit/thunks/binderAndManagementThunks.test.ts
@@ -322,8 +322,8 @@ describe('importProjectThunk', () => {
     });
     const action = await store.dispatch(importProjectThunk(file));
 
-    // saveImage called proves avatar was processed
-    expect(storageService.saveImage).toHaveBeenCalledWith('c2', 'base64imgdata');
+    // saveImage called proves avatar was processed, project-qualified by the imported project's own id
+    expect(storageService.saveImage).toHaveBeenCalledWith('proj-1', 'c2', 'base64imgdata');
     // hasAvatar flag set on the character entity in the payload
     const payload = (
       action as {

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -3,7 +3,7 @@
  * QNBS-v3: Mocks geminiService + Redux; tests createNewInterview factory + streamInterviewResponseThunk.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,6 +33,7 @@ vi.mock('uuid', () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
+import { appStoreRef } from '../../../app/storeRef';
 import {
   createNewInterview,
   streamInterviewResponseThunk,
@@ -231,5 +232,124 @@ describe('streamInterviewResponseThunk', () => {
     const result = await thunk(dispatch, getState, undefined);
     expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
     expect((result as { error: { message: string } }).error.message).toContain('interview-1');
+  });
+});
+
+// QNBS-v3: Wave 0B.1 -- streaming chunks must never mutate a project that is no longer active.
+describe('streamInterviewResponseThunk - project authority', () => {
+  function makeInterviewState() {
+    return {
+      project: {
+        present: {
+          data: {
+            characters: {
+              ids: ['char-1'],
+              entities: {
+                'char-1': {
+                  id: 'char-1',
+                  name: 'Alice',
+                  backstory: 'A brave hero',
+                  motivation: 'Save the world',
+                  personalityTraits: 'Courageous',
+                },
+              },
+            },
+            characterInterviews: {
+              'char-1': [
+                {
+                  id: 'interview-1',
+                  characterId: 'char-1',
+                  archetype: 'hero',
+                  templateId: 'tpl-1',
+                  messages: [],
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                },
+              ],
+            },
+          },
+        },
+      },
+      settings: {
+        present: {
+          advancedAi: { provider: 'gemini', model: 'gemini-2.5-flash', temperature: 0.7 },
+          aiCreativity: 'Balanced',
+        },
+      },
+    };
+  }
+
+  afterEach(() => {
+    appStoreRef.current = null;
+  });
+
+  it('drops a streaming chunk dispatched after the active project identity changed', async () => {
+    let liveState = { project: { present: { data: { id: 'proj-a' }, generation: 0 } } };
+    appStoreRef.current = {
+      getState: () => liveState as never,
+      dispatch: vi.fn() as never,
+    };
+
+    mockStreamText.mockImplementation(
+      async (
+        _prompt: unknown,
+        _creativity: unknown,
+        onChunk: (chunk: string) => void,
+        _signal: unknown,
+      ) => {
+        // QNBS-v3: simulates a project reset/import/switch completing while the stream is in flight.
+        liveState = { project: { present: { data: { id: 'proj-b' }, generation: 1 } } };
+        onChunk('late chunk');
+      },
+    );
+
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(makeInterviewState());
+    const thunk = streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Who are you?',
+    });
+
+    await thunk(dispatch, getState, undefined);
+
+    const chunkDispatch = dispatch.mock.calls.find(
+      (c) => c[0]?.type === 'project/streamInterviewChunk',
+    );
+    expect(chunkDispatch).toBeUndefined();
+  });
+
+  it('still dispatches streaming chunks when the active project is unchanged', async () => {
+    const liveState = { project: { present: { data: { id: 'proj-a' }, generation: 0 } } };
+    appStoreRef.current = {
+      getState: () => liveState as never,
+      dispatch: vi.fn() as never,
+    };
+
+    mockStreamText.mockImplementation(
+      async (
+        _prompt: unknown,
+        _creativity: unknown,
+        onChunk: (chunk: string) => void,
+        _signal: unknown,
+      ) => {
+        onChunk('normal chunk');
+      },
+    );
+
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(makeInterviewState());
+    const thunk = streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Who are you?',
+    });
+
+    await thunk(dispatch, getState, undefined);
+
+    const chunkDispatch = dispatch.mock.calls.find(
+      (c) => c[0]?.type === 'project/streamInterviewChunk',
+    );
+    expect(chunkDispatch).toBeDefined();
   });
 });

--- a/tests/unit/thunks/outlineAndWorldThunks.test.ts
+++ b/tests/unit/thunks/outlineAndWorldThunks.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import undoable from 'redux-undo';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // QNBS-v3: localStorageOnly defaults true in settingsReducer — bypass the cloud-AI gate so thunks can run.
 vi.mock('../../../services/ai/aiPolicy', () => ({
@@ -22,6 +22,7 @@ vi.mock('../../../services/storageService', () => ({
   },
 }));
 
+import { appStoreRef } from '../../../app/storeRef';
 import featureFlagsReducer from '../../../features/featureFlags/featureFlagsSlice';
 import projectReducer, { projectActions } from '../../../features/project/projectSlice';
 import {
@@ -78,6 +79,12 @@ beforeEach(() => {
   mockGetPrompts.mockReturnValue({ prompt: 'test-prompt', schema: {} });
   mockGenerateJson.mockResolvedValue([]);
   vi.mocked(storageService.saveImage).mockResolvedValue(undefined);
+  // QNBS-v3: default-identity store so captureActiveProjectIdentity() is stable and non-null by default; tests exercising the stale-project guard point appStoreRef.current at their own store instead.
+  appStoreRef.current = makeStore() as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -262,7 +269,7 @@ describe('generateWorldImageThunk', () => {
       generateWorldImageThunk({ worldId: 'w42', description: 'A volcanic wasteland', lang: 'en' }),
     );
 
-    expect(storageService.saveImage).toHaveBeenCalledWith('w42', 'worldimagedata');
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'w42', 'worldimagedata');
   });
 
   it('rejects on AI error', async () => {
@@ -274,6 +281,41 @@ describe('generateWorldImageThunk', () => {
 
     expect(action.type).toBe('project/generateWorldImage/rejected');
     expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+});
+
+// QNBS-v3: Wave 0B.1 -- image writes must reject before persistence when the active project changed mid-generation.
+describe('generateWorldImageThunk - project authority', () => {
+  it('rejects with a stale-project payload and never persists when the active project changed mid-generation', async () => {
+    const store = makeStore();
+    appStoreRef.current = store as never;
+    mockGenerateImage.mockImplementation(async () => {
+      store.dispatch(
+        projectActions.resetProject({ title: 'New', logline: '', chapter1Title: 'Ch1' }),
+      );
+      return 'worldimagedata';
+    });
+
+    const action = await store.dispatch(
+      generateWorldImageThunk({ worldId: 'w1', description: 'A misty forest', lang: 'en' }),
+    );
+
+    expect(action.type).toBe('project/generateWorldImage/rejected');
+    expect((action as { payload?: { staleProject?: boolean } }).payload?.staleProject).toBe(true);
+    expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+
+  it('persists normally when the active project is unchanged', async () => {
+    const store = makeStore();
+    appStoreRef.current = store as never;
+    mockGenerateImage.mockResolvedValue('worldimagedata');
+
+    const action = await store.dispatch(
+      generateWorldImageThunk({ worldId: 'w1', description: 'A misty forest', lang: 'en' }),
+    );
+
+    expect(action.type).toBe('project/generateWorldImage/fulfilled');
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'w1', 'worldimagedata');
   });
 });
 
@@ -294,7 +336,7 @@ describe('uploadWorldImageThunk', () => {
     const action = await store.dispatch(uploadWorldImageThunk({ worldId: 'w99', file }));
 
     expect(action.type).toBe('project/uploadWorldImage/fulfilled');
-    expect(storageService.saveImage).toHaveBeenCalledWith('w99', fakeDataUrl);
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'w99', fakeDataUrl);
   });
 
   it('rejects when the FileReader errors', async () => {

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import undoable from 'redux-undo';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // QNBS-v3: localStorageOnly defaults true in settingsReducer — bypass the cloud-AI gate so thunks can run.
 vi.mock('../../../services/ai/aiPolicy', () => ({
@@ -22,8 +22,9 @@ vi.mock('../../../services/storageService', () => ({
   },
 }));
 
+import { appStoreRef } from '../../../app/storeRef';
 import featureFlagsReducer from '../../../features/featureFlags/featureFlagsSlice';
-import projectReducer from '../../../features/project/projectSlice';
+import projectReducer, { projectActions } from '../../../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
   generateCharacterProfileThunk,
@@ -75,6 +76,12 @@ beforeEach(() => {
   } as never);
   vi.mocked(storageService.saveImage).mockResolvedValue(undefined);
   mockGetPrompts.mockReturnValue({ prompt: 'test-prompt', schema: { type: 'array' } });
+  // QNBS-v3: default-identity store so captureActiveProjectIdentity() is stable and non-null by default; tests exercising the stale-project guard point appStoreRef.current at their own store instead.
+  appStoreRef.current = makeStore() as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -202,7 +209,7 @@ describe('generateSceneImageThunk', () => {
     const store = makeStore();
     await store.dispatch(generateSceneImageThunk(payload));
 
-    expect(storageService.saveImage).toHaveBeenCalledWith('scene-sec-1', 'rawbase64');
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'scene-sec-1', 'rawbase64');
   });
 
   it('prefixes plain base64 with data:image/png;base64,', async () => {
@@ -223,6 +230,36 @@ describe('generateSceneImageThunk', () => {
 
     const result = (action as { payload: { imageKey: string; dataUrl: string } }).payload;
     expect(result.dataUrl).toBe('data:image/png;base64,alreadyprefixed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateSceneImageThunk — project authority (Wave 0B.1)
+// ---------------------------------------------------------------------------
+describe('generateSceneImageThunk - project authority', () => {
+  const payload = {
+    sectionId: 'sec-1',
+    sectionTitle: 'Chapter One',
+    sectionContent: 'Once upon a time...',
+    projectTitle: 'My Novel',
+    lang: 'en',
+  };
+
+  it('rejects with a stale-project payload and never persists when the active project changed mid-generation', async () => {
+    const store = makeStore();
+    appStoreRef.current = store as never;
+    mockGenerateImage.mockImplementation(async () => {
+      store.dispatch(
+        projectActions.resetProject({ title: 'New', logline: '', chapter1Title: 'Ch1' }),
+      );
+      return 'base64imagedata';
+    });
+
+    const action = await store.dispatch(generateSceneImageThunk(payload));
+
+    expect(action.type).toBe('project/generateSceneImage/rejected');
+    expect((action as { payload?: { staleProject?: boolean } }).payload?.staleProject).toBe(true);
+    expect(storageService.saveImage).not.toHaveBeenCalled();
   });
 });
 
@@ -390,7 +427,7 @@ describe('generateCharacterPortraitThunk', () => {
       }),
     );
 
-    expect(storageService.saveImage).toHaveBeenCalledWith('c42', 'portraitdata');
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'c42', 'portraitdata');
   });
 
   it('appends style to description when style is provided', async () => {
@@ -432,6 +469,52 @@ describe('generateCharacterPortraitThunk', () => {
 });
 
 // ---------------------------------------------------------------------------
+// generateCharacterPortraitThunk — project authority (Wave 0B.1)
+// ---------------------------------------------------------------------------
+describe('generateCharacterPortraitThunk - project authority', () => {
+  it('rejects with a stale-project payload and never persists when the active project changed mid-generation', async () => {
+    const store = makeStore();
+    appStoreRef.current = store as never;
+    mockGenerateImage.mockImplementation(async () => {
+      // QNBS-v3: simulates a New Project/import/restore completing while the portrait AI call was in flight.
+      store.dispatch(
+        projectActions.resetProject({ title: 'New', logline: '', chapter1Title: 'Ch1' }),
+      );
+      return 'portraitbase64';
+    });
+
+    const action = await store.dispatch(
+      generateCharacterPortraitThunk({
+        characterId: 'c1',
+        description: 'A tall warrior',
+        lang: 'en',
+      }),
+    );
+
+    expect(action.type).toBe('project/generateCharacterPortrait/rejected');
+    expect((action as { payload?: { staleProject?: boolean } }).payload?.staleProject).toBe(true);
+    expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+
+  it('persists normally when the active project is unchanged', async () => {
+    const store = makeStore();
+    appStoreRef.current = store as never;
+    mockGenerateImage.mockResolvedValue('portraitbase64');
+
+    const action = await store.dispatch(
+      generateCharacterPortraitThunk({
+        characterId: 'c1',
+        description: 'A tall warrior',
+        lang: 'en',
+      }),
+    );
+
+    expect(action.type).toBe('project/generateCharacterPortrait/fulfilled');
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'c1', 'portraitbase64');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // uploadCharacterImageThunk
 // ---------------------------------------------------------------------------
 // QNBS-v3: FileReader error/abort and storageService.saveImage-rejection coverage prevents the upload thunk's Promise from hanging forever on any terminal failure path.
@@ -454,7 +537,7 @@ describe('uploadCharacterImageThunk', () => {
     const action = await store.dispatch(uploadCharacterImageThunk({ characterId: 'c99', file }));
 
     expect(action.type).toBe('project/uploadCharacterImage/fulfilled');
-    expect(storageService.saveImage).toHaveBeenCalledWith('c99', fakeDataUrl);
+    expect(storageService.saveImage).toHaveBeenCalledWith('default', 'c99', fakeDataUrl);
   });
 
   it('dispatches fulfilled with characterId', async () => {
@@ -474,7 +557,11 @@ describe('uploadCharacterImageThunk', () => {
     const action = await store.dispatch(uploadCharacterImageThunk({ characterId: 'c7', file }));
 
     expect((action as { payload: { characterId: string } }).payload?.characterId).toBe('c7');
-    expect(storageService.saveImage).toHaveBeenCalledWith('c7', 'data:image/jpeg;base64,abc123');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'default',
+      'c7',
+      'data:image/jpeg;base64,abc123',
+    );
   });
 
   it('rejects when the FileReader errors', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Closes the P1 mutation-authority residuals identified in the post-#707 audit on #704 (tracked as #708): AI-generated character/world portraits and scene-visualization images were persisted and applied to the active project with no check that the requesting project was still active, and images were keyed only by entity id (not project id) — so two stored projects sharing an entity id (e.g. one imported from the other's export, which preserves ids verbatim) could silently overwrite each other's image. Character Interview streaming, Writer's generation history, and Global Copilot's transcript had the same "project-unowned AI result" gap.

- `generateCharacterPortraitThunk` / `generateWorldImageThunk` / `generateSceneImageThunk` now capture project identity before the AI call and `rejectWithValue` a stale-project sentinel *before* the persistent write/reducer mutation — a hook-level check after the thunk resolves is already too late for `saveImage`.
- `storageService.saveImage/getImage/deleteImage` are now project-qualified on both the IndexedDB and desktop filesystem backends (mirroring the existing binder-asset key convention), with a legacy-key read-through so pre-existing images stay reachable without a forced migration.
- `streamInterviewResponseThunk` drops streaming chunks once the active project identity changes mid-stream.
- New `app/listenerMiddleware.ts` listeners invalidate Writer's `generationHistory`/`resultStream` and Global Copilot's transcript on project-generation change, so a stale AI result from another project can never be accepted via `handleAccept()`/`applyLastSuggestion()`.

## Test plan
- [x] `pnpm run lint`
- [x] `npx tsgo --project tsconfig.tsgo.json --noEmit --checkers 1` (single-checker; this machine cannot run the full 4-checker gate — required CI runs it)
- [x] Targeted `vitest run` across all 16 affected test files (413 tests) — full pass
- [x] Each new guard mutation-tested (temporarily disabled, confirmed the exact expected test fails, restored): image-write stale-reject, interview-chunk stale-drop, Writer/Copilot generation-change listeners, legacy-key fallback
- [x] `pnpm run ci:prepush`

## Summary by Sourcery

Reject stale AI results before persistence or application and isolate image storage by project.

Bug Fixes:
- Prevent stale AI-generated portraits, world images, scene visualizations, and interview streams from mutating the active project after a project change.
- Prevent image collisions between projects that share entity IDs by scoping image storage to the owning project.
- Preserve access to pre-existing unscoped images while ensuring explicit deletion removes both legacy and project-scoped copies.
- Suppress misleading failure notifications when AI results are intentionally discarded because the project changed.

Enhancements:
- Invalidate Writer generation state and Global Copilot conversations when the project incarnation changes so stale results cannot be accepted or applied.

Tests:
- Add coverage for stale AI write rejection, streaming invalidation, project-state cleanup, project-qualified image storage, legacy image fallback, and stale-result notification behavior.


___

## **CodeAnt-AI Description**
Prevent stale AI results from being saved or applied after switching projects

### What Changed
- AI-generated portraits, world images, and scene images are discarded before saving when the active project changes during generation
- Images are stored and loaded per project, preventing projects with matching character or world IDs from overwriting each other
- Existing images saved before this change remain available, while deleting an image removes both old and new copies
- Character Interview stops applying late streaming chunks after a project switch
- Writer history and Copilot conversations are cleared when a new project incarnation is opened
- Switching projects during an AI request no longer shows a misleading failure message

### Impact
`✅ Prevented cross-project image overwrites`
`✅ No stale AI changes after project switches`
`✅ Clearer behavior when AI requests become outdated`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented AI-generated images and streaming responses from being applied to the wrong project after switching projects.
  - Isolated image storage by project while retaining access to existing images.
  - Cleared temporary writing and chat state when project generation changes.
  - Suppressed misleading error notifications when outdated requests are safely discarded.

- **Documentation**
  - Updated README test-count metrics.

- **Tests**
  - Expanded coverage for project switching, stale results, storage compatibility, and state reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->