### PR TITLE
docs(proforge): plan real token accounting for the Claude path

### DIFF
--- a/docs/PROFORGE-CLAUDE-TOKEN-ACCOUNTING-PLAN.md
+++ b/docs/PROFORGE-CLAUDE-TOKEN-ACCOUNTING-PLAN.md
@@ -1,0 +1,41 @@
+# Plan: real token accounting for the Claude path (ProForge)
+
+Status: **planned, not yet implemented** — prep doc from a `/claude-api prompt-audit` pass (2026-09-12). Implement in this branch (`fix/proforge-token-accounting`) when work resumes.
+
+## Finding
+
+`ProForge` agents label a raw **character** count as "tokens":
+
+- `services/proForge/pipelineAgents/structuralAgent.ts:67` — `tokensConsumed += response.length;`
+- `services/proForge/pipelineAgents/diagnosticAgent.ts:72,91` — same pattern (initial call + retry)
+- `services/proForge/pipelineAgents/publishingAgent.ts:52`
+- `services/proForge/pipelineAgents/proofAgent.ts:51`
+- `services/proForge/pipelineAgents/proseAgent.ts:91` (per-section loop)
+- `services/proForge/pipelineAgents/copyEditAgent.ts:67` (per-section loop)
+- `services/proForge/pipelineAgents/baseAgent.ts:213` — `selfReflect()`'s `tokensUsed: response.text.length`
+
+`services/aiProviderService.ts:362-369` (`deliverAnthropicResponse`) reads the full Anthropic response JSON and discards `json.usage` entirely — the real `usage.input_tokens`/`usage.output_tokens` (and thinking-token spend on Opus 5, which runs adaptive thinking by default) never reach the app. `AnalyticsAgent` has no AI call and needs no change.
+
+## Small fix (low risk, do first)
+
+Swap the character count for the existing token estimator already used elsewhere in this codebase (`services/ragPromptAssembly.ts:51-53`, `estimateTokens`):
+
+```ts
+export function estimateTokens(text: string): number {
+  return Math.ceil((text.length / 4) * 1.3);
+}
+```
+
+Import it in each of the six files above and replace `response.length` / `response.text.length` with `estimateTokens(response)` / `estimateTokens(response.text)`. Mechanical, no interface changes, no test breakage expected beyond any test asserting the old raw-length value.
+
+## Larger fix (design decision needed, not a blind diff)
+
+Thread Anthropic's real `usage` object back through the call chain instead of estimating:
+
+1. `deliverAnthropicResponse` (`services/aiProviderService.ts:357-372`) already has `json.usage` available — capture `{ inputTokens, outputTokens }` instead of discarding it.
+2. That requires extending `AIStreamCallbacks`/`generateText`'s return shape (currently just `Promise<string>`) to optionally carry usage, or a side-channel the ProForge agents can read. This is an interface change affecting every provider path (only Anthropic can populate it for now; others stay `undefined`) — decide the shape with the user before implementing, don't force it through as a mechanical hunk.
+3. Once available, `structuralAgent.ts` etc. should prefer real `usage.output_tokens` when present, falling back to `estimateTokens()` for providers that don't return it.
+
+## Why this matters
+
+Without real usage data, the `MAX_TOKENS_CEILING`/timeout tuning in the companion plan (`docs/PROFORGE-CLAUDE-MAXTOKENS-CEILING-PLAN.md`) can't be validated from measurement — right now nobody can tell whether the app's self-imposed ceilings are actually being hit.


### PR DESCRIPTION
## **User description**
## Summary
- Prep-only PR from a `/claude-api prompt-audit` pass — captures a concrete finding and fix plan so next week's session can implement directly instead of re-auditing.
- ProForge agents label raw character counts (`response.length`) as "tokens" across 6 files; the real Anthropic `usage` object is read and discarded in `deliverAnthropicResponse`.
- Doc: `docs/PROFORGE-CLAUDE-TOKEN-ACCOUNTING-PLAN.md` — exact file:line targets, a low-risk mechanical fix (swap in the existing `estimateTokens()` helper), and a larger flagged follow-up (thread real `usage.output_tokens` through the call chain) that needs a design decision before implementing.

## Test plan
- [ ] No code changes in this PR — docs only.
- [ ] Next session: apply the mechanical `estimateTokens()` swap, run `pnpm run typecheck` + `pnpm run lint`, then this PR is ready to merge.

## Summary by Sourcery

Document a staged plan to correct ProForge token accounting without changing runtime behavior in this preparation-only pull request.

Enhancements:
- Document the identified ProForge token-accounting discrepancies and a staged plan to replace character counts with safe token estimates, then later expose provider-reported usage after the required interface decisions.

Documentation:
- Add a planning document covering affected agents, safe estimator extraction, Anthropic usage propagation, and the output-versus-total token accounting decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds and corrects a planning doc for fixing ProForge's token accounting: seven agent files count raw character length as tokens, and the real Anthropic `usage` data is discarded. The plan covers `baseAgent.ts` (its raw `selfReflect()` count leaks into two agents), points at current code locations, and requires extracting `estimateTokens()` into a dependency-free module before swapping, with `ragPromptAssembly.ts` re-exporting it because tests import it from there. `selfReflect()` also needs `estimateTokens(response.text)` since it returns an object, unlike the other eight string-returning call sites across the remaining six files. The larger fix to thread real `usage` through `GenerateResult` stays deferred pending a design decision. No code changes in this PR.

<sup>Written for commit d87c7cc73f63554cc1728405067703185c30666a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the token accounting plan with clarified implementation details.
  - Documented preservation of the existing token-estimation export for compatibility.
  - Clarified usage fallback behavior across string-returning agent responses.
  - Specified that reflection accounting uses response text.
  - No implementation changes were made in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Document a staged plan to correct ProForge token accounting

### What Changed
- Identifies seven ProForge agent files that currently report character counts as token usage, including reflection and retry paths
- Defines a low-risk first step to use a dependency-free token estimate without disrupting Node-based agent execution or existing tests
- Maps the larger follow-up needed to preserve Anthropic input and output usage through the inference flow
- Clarifies that per-call totals must remain additive and that the meaning of `tokensConsumed` requires a decision before implementation

### Impact
`✅ Accurate token-accounting implementation path`
`✅ Safer ProForge execution across Node and browser environments`
`✅ Measurable Anthropic usage for token-limit tuning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
