### PR TITLE
docs(proforge): plan Claude max_tokens/timeout right-sizing

### DIFF
--- a/docs/PROFORGE-CLAUDE-MAXTOKENS-CEILING-PLAN.md
+++ b/docs/PROFORGE-CLAUDE-MAXTOKENS-CEILING-PLAN.md
@@ -1,0 +1,42 @@
+# Plan: right-size the Claude web-path ceiling/timeout (ProForge)
+
+Status: **planned, not yet implemented** — prep doc from a `/claude-api prompt-audit` pass (2026-09-12). Implement in this branch (`fix/proforge-anthropic-maxtokens-ceiling`) when work resumes.
+
+## Finding
+
+The Anthropic relay and several ProForge agents cap output far below what the target models (`claude-opus-5`/`claude-sonnet-5`, per `services/ai/cloudModelCatalog.ts`) actually support, and the web path never streams:
+
+- `api/_shared/claudeProxyCore.ts:15` — `MAX_TOKENS_CEILING = 8192` (zod `.max()` on the request — an **over-limit request is rejected outright**, not clamped)
+- `api/_shared/claudeProxyCore.ts:16` — `OUTBOUND_TIMEOUT_MS = 20_000`
+- `api/_shared/claudeProxyCore.ts:146-168` — single blocking `fetch()` + one `.text()` read; no SSE
+- `services/aiProviderService.ts:357-372` (`deliverAnthropicResponse`) — delivers the whole response as **one** `onChunk` call; "streaming" is fake for Claude specifically (OpenAI/Grok/Ollama paths do real SSE)
+- `services/proForge/pipelineAgents/baseAgent.ts:178` — default `cfg.maxTokens ?? 8192`
+- Extra-tight per-call caps, all hardcoded to `4000`: `publishingAgent.ts:50`, `proofAgent.ts:49`, `proseAgent.ts:89`, `copyEditAgent.ts:65`
+
+## Verified constraint (from the current Claude API docs, checked 2026-09-12)
+
+Claude Opus 5 / Sonnet 5 support **up to 128K output tokens**, but the API requires **streaming** to use values that large without hitting HTTP timeouts. Opus 5 also runs **adaptive thinking on by default** (unlike Opus 4.8/4.7), which adds latency before any visible output — compounding the risk under a 20s non-streaming timeout. Large ProForge payloads (up to 100 structural edits, or the full publishing package) are exactly the shape most likely to get truncated or time out under the current ceiling.
+
+## Two-part fix
+
+**Part A — mechanical, low risk (do first):**
+
+```diff
+- const MAX_TOKENS_CEILING = 8192;
+- const OUTBOUND_TIMEOUT_MS = 20_000;
++ const MAX_TOKENS_CEILING = 32_000;
++ const OUTBOUND_TIMEOUT_MS = 55_000;
+```
+
+Raise the four `4000` per-call caps: `publishingAgent.ts`/`proofAgent.ts` (whole-manuscript scope, heavier output) → `16_000`; `proseAgent.ts`/`copyEditAgent.ts` (per-section, runs in a loop up to 5×/3× per stage) → `8_000`. All within the raised `MAX_TOKENS_CEILING`.
+
+**Part B — real streaming, needs design time (flag, don't blind-diff):**
+
+Genuine 128K-scale output still needs true SSE end-to-end: the Cloudflare/Vercel Pages Function currently reads the whole upstream body before responding, and `deliverAnthropicResponse` delivers it as one chunk. Fixing this means streaming through the edge function (`api/_shared/claudeProxyCore.ts:146`) and switching `deliverAnthropicResponse` (`services/aiProviderService.ts:357`) to a real reader loop that calls `callbacks.onChunk` incrementally. Worth doing, but it's an architecture change, not a one-line hunk — scope it as its own PR once Part A is in and measured (see `docs/PROFORGE-CLAUDE-TOKEN-ACCOUNTING-PLAN.md` for the usage-visibility prerequisite).
+
+## Implementation checklist for next session
+
+1. Apply Part A's diff (5 files above).
+2. Run `pnpm run typecheck` + `pnpm run lint`.
+3. Sanity-check a ProForge run locally against a real Claude API key if available, watching for the proxy's 400 (over-ceiling) or 504 (timeout) responses disappearing.
+4. Decide whether to also tackle Part B in the same PR or split it further.


### PR DESCRIPTION
## **User description**
## Summary
- Prep-only PR from a `/claude-api prompt-audit` pass — captures a concrete finding and fix plan so next week's session can implement directly instead of re-auditing.
- The Anthropic relay (`api/_shared/claudeProxyCore.ts`) and 4 ProForge agents cap Claude output at 4-8K tokens with a 20s non-streaming timeout — sized for an older/smaller model than the ones this app's own catalog now targets (`claude-opus-5`/`claude-sonnet-5`, which support up to 128K output but need streaming to use it, and where Opus 5 runs adaptive thinking on by default).
- Doc: `docs/PROFORGE-CLAUDE-MAXTOKENS-CEILING-PLAN.md` — exact file:line targets, a low-risk mechanical fix (raise the ceiling/timeout constants), and a flagged larger follow-up (real SSE streaming through the edge function) that needs its own design pass.

## Test plan
- [ ] No code changes in this PR — docs only.
- [ ] Next session: apply the mechanical ceiling/timeout diff, run `pnpm run typecheck` + `pnpm run lint`, then this PR is ready to merge.

## Summary by Sourcery

Document the plan to right-size Claude response limits and clarify the follow-up work required for reliable large-output streaming.

Enhancements:
- Document the current Claude response ceiling, timeout, and lack of end-to-end streaming across the ProForge web and desktop paths.
- Define a staged remediation plan for increasing token budgets and timeouts, including default-budget, provider-scoping, and security-impact decisions.
- Scope genuine Claude SSE streaming as a separate architecture follow-up rather than presenting it as implemented.

Documentation:
- Add a ProForge Claude capacity plan documenting findings, proposed changes, validation steps, and security reassessment requirements.


___

## **CodeAnt-AI Description**
Document a corrected plan for handling larger Claude responses in ProForge

### What Changed
- Records the current Claude limits, including rejected over-limit requests, 20-second timeouts, and buffered responses that do not stream to users
- Corrects the effective default token budget and explains why raising agent-level caps alone would have little impact for typical users
- Defines a staged fix to raise output and timeout limits, update the security assessment, and decide whether changes apply only to Claude or all providers
- Separates genuine end-to-end streaming for web and desktop responses into a follow-up architecture change

### Impact
`✅ Clearer plan for larger ProForge outputs`
`✅ Fewer unexpected Claude timeouts after implementation`
`✅ Explicit security review for longer public relay requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
