### PR TITLE
feat(proforge): plan Claude structured-outputs wiring

### DIFF
--- a/docs/PROFORGE-CLAUDE-STRUCTURED-OUTPUTS-PLAN.md
+++ b/docs/PROFORGE-CLAUDE-STRUCTURED-OUTPUTS-PLAN.md
@@ -1,0 +1,63 @@
+# Plan: wire Claude's native structured outputs into ProForge
+
+Status: **planned, not yet implemented** — prep doc from a `/claude-api prompt-audit` pass (2026-09-12). Implement in this branch (`feat/proforge-claude-structured-outputs`) when work resumes. This is the largest of the three audit follow-ups; the other two (`docs/PROFORGE-CLAUDE-TOKEN-ACCOUNTING-PLAN.md`, `docs/PROFORGE-CLAUDE-MAXTOKENS-CEILING-PLAN.md`) are independent and smaller.
+
+## Finding
+
+Every JSON-producing ProForge stage asks Claude for JSON **in prose**, then hand-parses the reply:
+
+- `services/proForge/pipelineOutput/structuredOutput.ts:386-392` (`stripJsonFences`) is the shared helper; the pattern it feeds is duplicated in `diagnosticAgent.ts:167-182`, `structuralAgent.ts:156-171`, `proseAgent.ts:93-124` (per-section), `copyEditAgent.ts:69-100` (per-section), `proofAgent.ts:55-70`, `publishingAgent.ts:56-71`: `stripJsonFences` → `JSON.parse` → on failure, a `/\{[\s\S]*\}/` regex brace-match → parse again → Zod `validateWithSchema`.
+- Prose instructions live in `services/promptLibrary.ts:321,331,341,351,361,371` ("Return JSON with…") and `:251` ("Return JSON only: {…}").
+- `AnalyticsAgent` makes no AI call — out of scope.
+
+The app already owns complete Zod schemas for every one of these six shapes in `structuredOutput.ts` (`diagnosticReportSchema`, `structuralEditPlanSchema`, `proseEditBatchSchema`, `copyEditPlanSchema`, `qualityGateReportSchema`, `publishingPackageSchema`) — it's just never handing them to the model.
+
+## Verified Anthropic API constraints (checked live, 2026-09-12 — do not re-derive, use this)
+
+Raw wire shape for `output_config.format` (confirmed against `https://platform.claude.com/docs/en/build-with-claude/structured-outputs`, since this app calls the Messages API via raw `fetch`, not the `@anthropic-ai/sdk` package):
+
+```json
+{
+  "output_config": {
+    "format": {
+      "type": "json_schema",
+      "schema": { "type": "object", "properties": { "...": "..." }, "required": ["..."], "additionalProperties": false }
+    }
+  }
+}
+```
+
+**Response shape is unchanged** — the JSON comes back as plain text in a `type: "text"` content block, exactly like today. There is no `parsed_output` field at the raw-HTTP level (that's an SDK-only convenience from `client.messages.parse()`). This means `deliverAnthropicResponse` (`services/aiProviderService.ts:357-372`) needs **zero changes** — only the request side changes. Keep `stripJsonFences`/`validateWithSchema` in place as a defense-in-depth safety net; don't remove them.
+
+**Hard schema constraints — a schema violating these gets a 400:**
+
+- `additionalProperties: false` is **required on every object node**, at every nesting level.
+- **Not supported, will 400 if present:** `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf` (numeric), `minLength`, `maxLength` (string), `maxItems`/`minItems` other than 0 or 1 (array).
+- Supported: basic types, `enum` (strings/numbers/bools/null only, no complex types), `const`, `anyOf`/`allOf` (not `allOf` with `$ref`), internal `$ref`/`$defs`/`definitions` (no external `$ref`), `default`, string `format` (`date-time`, `date`, `email`, `uuid`, etc.).
+
+**This is exactly the problem**: every schema in `structuredOutput.ts` uses `.min()/.max()` on numbers (`qualityScoreSchema`'s 7 fields, `confidence: z.number().min(0).max(1)` everywhere) and `.max()` on arrays (`consistencyIssues.max(50)`, `edits.max(100)`, etc.) and strings (`summary: z.string().max(2000)`). A naive `z.toJSONSchema(schema)` (Zod 4.4.3 is already installed, `z.toJSONSchema` exists) would emit `minimum`/`maximum`/`maxLength`/`maxItems` everywhere and every one of the six calls would 400.
+
+## Why not just add `@anthropic-ai/sdk` and use `zodOutputFormat()`
+
+The skill's recommended path (`zodOutputFormat(schema)` from `@anthropic-ai/sdk/helpers/zod`) auto-strips the unsupported keywords and is the officially-blessed approach — but this repo has **no** `@anthropic-ai/sdk` dependency anywhere; it deliberately uses raw `fetch` for the whole Anthropic path (browser bundle + the edge proxy) to stay dependency-light and avoid CORS/bundle-size issues. Pulling in the full Node SDK just for one schema-conversion helper is a heavy tradeoff for a client bundle. Decide this explicitly next session — it's the one open design choice here — between:
+
+- **(a)** write a small local sanitizer (recursive walk over `z.toJSONSchema()`'s output: drop `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`/`minLength`/`maxLength`, drop `maxItems`/`minItems` > 1, force `additionalProperties: false` onto every `type: "object"` node including inside `$defs`), or
+- **(b)** add `@anthropic-ai/sdk` (server-only, e.g. scoped to the edge function if bundling allows) and use `zodOutputFormat()` directly.
+
+(a) matches the existing architecture; (b) is less code to maintain but a new dependency in a codebase that has specifically avoided one here before (see `functions/api/claude-proxy.ts`'s own comment about avoiding `@cloudflare/workers-types` for a single type). Lean (a) unless bundle placement makes (b) trivial.
+
+## Plumbing (files to touch, in order)
+
+1. `api/_shared/claudeProxyCore.ts` — add an optional `responseSchema: z.record(z.string(), z.unknown()).optional()` field to `claudeProxyRequestSchema` (bounded by the existing `MAX_BODY_BYTES` cap, no separate size limit needed); pass it through as `output_config.format` on the upstream request when present.
+2. `services/aiProviderService.ts` — add `responseSchema?: Record<string, unknown>` to `AIRequestOptions`; thread it into **both** `streamAnthropic` branches (the Tauri-direct desktop path at `:397-413` and the proxy path at `:415-427`). No other provider reads this field — safe no-op for OpenAI/Grok/Gemini/Ollama/OpenRouter/local.
+3. `services/proForge/pipelineAgents/baseAgent.ts` — `generate()` (`:117-130`) gains an optional third `responseSchema` param, forwarded into `buildAiOpts()`. `InferenceGateway.generate()` (`services/ai/inferenceGateway.ts`) needs **no changes** — it already forwards `options: AIRequestOptions` wholesale to `generateText()`.
+4. New helper, e.g. `services/proForge/pipelineOutput/anthropicJsonSchema.ts`, exporting `toAnthropicJsonSchema(schema: z.ZodType): Record<string, unknown>` implementing option (a) above if chosen.
+5. Six call sites — pass the converted schema as the third arg: `diagnosticAgent.ts` (`diagnosticReportSchema`), `structuralAgent.ts` (`structuralEditPlanSchema`), `proseAgent.ts` (`proseEditBatchSchema`, per-section), `copyEditAgent.ts` (`copyEditPlanSchema`, per-section), `proofAgent.ts` (`qualityGateReportSchema`), `publishingAgent.ts` (`publishingPackageSchema`).
+6. Leave the "Return JSON with…" prose in `promptLibrary.ts` untouched — it's still load-bearing for every non-Anthropic provider (Gemini has its own native JSON path already; OpenAI/Grok/Ollama/OpenRouter/local all still need the prose instruction). Redundant-but-harmless for Claude once structured outputs are wired.
+
+## Verification plan for next session
+
+1. Implement the chosen sanitizer/dependency approach.
+2. Write a throwaway script (`npx tsx` one-shot, not a committed file) that runs `toAnthropicJsonSchema()` against all six schemas and asserts: no `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`/`minLength`/`maxLength` keys anywhere in the output, no `maxItems`/`minItems` > 1, and `additionalProperties: false` present on every object node (including inside `$defs`). This is checkable without live API access.
+3. `pnpm run typecheck` + `pnpm run lint`.
+4. If a real Anthropic API key is available, smoke-test one stage (e.g. `DiagnosticAgent`) end-to-end and confirm the response still parses via the existing `validateWithSchema` safety net.


### PR DESCRIPTION
## **User description**
## Summary
- Prep-only PR from a `/claude-api prompt-audit` pass — captures the largest of the three audit follow-ups so next week's session can implement directly instead of re-auditing or re-researching the API.
- Every JSON-producing ProForge stage (6 of 8 agents) asks Claude for JSON in prose, then hand-parses it with `stripJsonFences` + a regex brace-match fallback — even though the app already owns complete Zod schemas for every one of those shapes.
- Doc: `docs/PROFORGE-CLAUDE-STRUCTURED-OUTPUTS-PLAN.md` — the verified live wire shape and hard constraints of `output_config.format` (fetched from Anthropic's current docs, 2026-09-12: `additionalProperties: false` required everywhere, `minimum`/`maximum`/`minLength`/`maxLength`/`maxItems>1` all rejected with a 400 — which every existing schema in this repo currently uses), the one open design decision (small local schema sanitizer vs. adding `@anthropic-ai/sdk` just for `zodOutputFormat()`), the full plumbing path file-by-file, and a verification plan that doesn't require live API access.

## Test plan
- [ ] No code changes in this PR — docs only.
- [ ] Next session: pick the sanitizer approach, implement the plumbing across the 6 files listed, verify with the throwaway schema-shape script described in the doc, then `pnpm run typecheck` + `pnpm run lint`.

## Summary by Sourcery

Prepare the ProForge migration to Claude native structured outputs without changing runtime behavior.

Enhancements:
- Document the migration plan for ProForge’s JSON-producing Claude requests to use native structured outputs across six agents and all eight generation calls, including retries.
- Record Anthropic schema constraints, conversion trade-offs, request plumbing, and offline verification requirements for the future implementation.

Documentation:
- Add a detailed ProForge structured-outputs implementation plan covering API behavior, schema sanitization, affected files, and regression testing.

Chores:
- Update the changelog to note that Claude structured-outputs wiring is planned but not yet implemented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a planning document and changelog entry for wiring Claude structured outputs into ProForge; runtime behavior remains unchanged because implementation is still pending.

- Covers all six response schemas and eight `generate()` calls, including diagnostic and structural retries.
- Records Anthropic’s schema constraints, bound-preservation requirements, and the desktop direct-request path that affects the `@anthropic-ai/sdk` option.
- Defines the file-by-file implementation path and offline verification, regression tests, typecheck, and lint steps.

<sup>Written for commit aebb41c7a5cf663b13eeb3119e004bb45f4202b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Plan the migration of ProForge’s JSON-producing Claude requests to native structured outputs

### What Changed
- Documents how six ProForge stages and their retry requests will pass response schemas to Claude instead of relying on prose JSON parsing alone
- Defines Anthropic schema constraints, including required object properties and unsupported validation limits
- Records the desktop and proxy request paths, dependency trade-offs, schema-sanitization requirements, and bound-preservation rules
- Adds an implementation and verification plan covering all affected agents, request branches, regression tests, and offline schema checks

### Impact
`✅ Clearer implementation path for Claude structured responses`
`✅ Fewer malformed JSON responses reaching ProForge stages`
`✅ Preserved validation rules during future schema conversion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>